### PR TITLE
made _validate_file work on Windows

### DIFF
--- a/bids/layout/index.py
+++ b/bids/layout/index.py
@@ -81,7 +81,7 @@ class BIDSLayoutIndexer(object):
         # BIDS validator expects absolute paths, but really these are relative
         # to the BIDS project root.
         to_check = os.path.relpath(f, self.root)
-        to_check = os.path.join('/', to_check)
+        to_check = os.path.join(os.path.sep, to_check)
         return self.validator.is_bids(to_check)
 
     def _index_dir(self, path, config, default_action=None):

--- a/bids/layout/index.py
+++ b/bids/layout/index.py
@@ -3,6 +3,7 @@
 import os
 import json
 from collections import defaultdict
+from pathlib import Path
 from bids_validator import BIDSValidator
 from .models import Config, Entity, Tag, FileAssociation
 from ..utils import listify, make_bidsfile
@@ -82,6 +83,7 @@ class BIDSLayoutIndexer(object):
         # to the BIDS project root.
         to_check = os.path.relpath(f, self.root)
         to_check = os.path.join(os.path.sep, to_check)
+        to_check = Path(to_check).as_posix()  # bids-validator works with posix paths only
         return self.validator.is_bids(to_check)
 
     def _index_dir(self, path, config, default_action=None):


### PR DESCRIPTION
Changed `'/'` to `os.path.sep`  which will work both with POSIX and Windows paths.

The issue where the problem was raised: bids-standard/pybids#425